### PR TITLE
DEVOPS | using resources directory to dynamically  load yaml pod template

### DIFF
--- a/resources/pod-templates/gradle-template.yaml
+++ b/resources/pod-templates/gradle-template.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Pod
+spec:
+  containers:
+  - name: gradle
+    image: gradle:latest
+    command: [cat]
+    tty: true

--- a/templates/gh-darinpope/Jenkinsfile
+++ b/templates/gh-darinpope/Jenkinsfile
@@ -1,20 +1,11 @@
+def gradle_pod_template = libraryResource 'pod-templates/gradle-template.yaml'
+
 pipeline {
     agent {
         kubernetes {
             label "ghdp2"
             defaultContainer "jnlp"
-            yaml """
-apiVersion: v1
-kind: Pod
-spec:
-  containers:
-  - name: gradle
-    image: gradle:latest
-    command:
-    - cat
-    tty: true
-"""
-        }
+            yaml gradle_pod_template
     }
   stages {
     stage('Build') {

--- a/templates/springboot-gradle-app/Jenkinsfile
+++ b/templates/springboot-gradle-app/Jenkinsfile
@@ -1,19 +1,11 @@
+def gradle_pod_template = libraryResource 'pod-templates/gradle-template.yaml'
+
 pipeline {
     agent {
         kubernetes {
             label "sbgr2"
             defaultContainer "jnlp"
-            yaml """
-apiVersion: v1
-kind: Pod
-spec:
-  containers:
-  - name: gradle
-    image: gradle:latest
-    command:
-    - cat
-    tty: true
-"""
+            yaml gradle_pod_template
         }
     }
     options {


### PR DESCRIPTION
A `resources` directory allows the **`libraryResource`** step to be used from an external library to load associated non-Groovy files.

This PR is adding the `resources` directory & reads the `gradle-template.yaml` dynamically.

### Advantage :- 
1. Loosely Coupled 
2. Easy to maintain.
